### PR TITLE
feat: refactored to create Lacework integration in-module

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -12,6 +12,21 @@ terraform {
 # AWS Management Account
 provider "aws" {}
 
+provider "lacework" {
+  organization = true
+}
+
+module "aws_org_cloudtrail" {
+  source  = "lacework/cloudtrail/aws"
+  version = "~> 2.0"
+
+  bucket_logs_enabled   = false
+  consolidated_trail    = true
+  is_organization_trail = true
+
+  create_lacework_integration = false
+}
+
 module "lacework_organization_sync_module" {
   source = "github.com/alannix-lw/terraform-aws-organization-sync"
 
@@ -21,7 +36,10 @@ module "lacework_organization_sync_module" {
   lacework_api_secret = "<Lacework API Secret>"
 
   # Integration Configuration
-  lacework_integration_guid = "<Lacework CloudTrail Integration GUID>"
+  lacework_iam_role_arn         = module.aws_org_cloudtrail.iam_role_arn
+  lacework_iam_role_external_id = module.aws_org_cloudtrail.external_id
+  lacework_sqs_queue_url        = module.aws_org_cloudtrail.sqs_url
+
   lacework_default_account  = "<Lacework Account>"
   lacework_org_map = {
     "<Lacework Sub-Account 1>" = ["<AWS Organization OU 1>", "<AWS Organization OU 2>"],

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,21 @@
 # AWS Management Account
 provider "aws" {}
 
+provider "lacework" {
+  organization = true
+}
+
+module "aws_org_cloudtrail" {
+  source  = "lacework/cloudtrail/aws"
+  version = "~> 2.0"
+
+  bucket_logs_enabled   = false
+  consolidated_trail    = true
+  is_organization_trail = true
+
+  create_lacework_integration = false
+}
+
 module "lacework_organization_sync_module" {
   source = "../.."
 
@@ -10,7 +25,10 @@ module "lacework_organization_sync_module" {
   lacework_api_secret = "<Lacework API Secret>"
 
   # Integration Configuration
-  lacework_integration_guid = "<Lacework CloudTrail Integration GUID>"
+  lacework_iam_role_arn         = module.aws_org_cloudtrail.iam_role_arn
+  lacework_iam_role_external_id = module.aws_org_cloudtrail.external_id
+  lacework_sqs_queue_url        = module.aws_org_cloudtrail.sqs_url
+
   lacework_default_account  = "<Lacework Account>"
   lacework_org_map = {
     "<Lacework Sub-Account 1>" = ["<AWS Organization OU 1>", "<AWS Organization OU 2>"],

--- a/examples/non-management-account/README.md
+++ b/examples/non-management-account/README.md
@@ -21,6 +21,10 @@ provider "aws" {
   profile = "non-management"
 }
 
+provider "lacework" {
+  organization = true
+}
+
 resource "aws_iam_role" "organization_sync" {
   providers = {
     aws = aws.management
@@ -70,6 +74,17 @@ resource "aws_iam_role_policy" "organization_sync_organization_policy" {
 EOF
 }
 
+module "aws_org_cloudtrail" {
+  source  = "lacework/cloudtrail/aws"
+  version = "~> 2.0"
+
+  bucket_logs_enabled   = false
+  consolidated_trail    = true
+  is_organization_trail = true
+
+  create_lacework_integration = false
+}
+
 module "lacework_organization_sync_module" {
   source = "github.com/alannix-lw/terraform-aws-organization-sync"
 
@@ -83,7 +98,10 @@ module "lacework_organization_sync_module" {
   lacework_api_secret = "<Lacework API Secret>"
 
   # Integration Configuration
-  lacework_integration_guid = "<Lacework CloudTrail Integration GUID>"
+  lacework_iam_role_arn         = module.aws_org_cloudtrail.iam_role_arn
+  lacework_iam_role_external_id = module.aws_org_cloudtrail.external_id
+  lacework_sqs_queue_url        = module.aws_org_cloudtrail.sqs_url
+
   lacework_default_account  = "<Lacework Account>"
   lacework_org_map = {
     "<Lacework Sub-Account 1>" = ["<AWS Organization OU 1>", "<AWS Organization OU 2>"],

--- a/examples/non-management-account/main.tf
+++ b/examples/non-management-account/main.tf
@@ -10,6 +10,10 @@ provider "aws" {
   profile = "non-management"
 }
 
+provider "lacework" {
+  organization = true
+}
+
 resource "aws_iam_role" "organization_sync" {
   provider = aws.management
 
@@ -55,6 +59,17 @@ resource "aws_iam_role_policy" "organization_sync_organization_policy" {
 EOF
 }
 
+module "aws_org_cloudtrail" {
+  source  = "lacework/cloudtrail/aws"
+  version = "~> 2.0"
+
+  bucket_logs_enabled   = false
+  consolidated_trail    = true
+  is_organization_trail = true
+
+  create_lacework_integration = false
+}
+
 module "lacework_organization_sync_module" {
   source = "../.."
 
@@ -68,7 +83,10 @@ module "lacework_organization_sync_module" {
   lacework_api_secret = "<Lacework API Secret>"
 
   # Integration Configuration
-  lacework_integration_guid = "<Lacework CloudTrail Integration GUID>"
+  lacework_iam_role_arn         = module.aws_org_cloudtrail.iam_role_arn
+  lacework_iam_role_external_id = module.aws_org_cloudtrail.external_id
+  lacework_sqs_queue_url        = module.aws_org_cloudtrail.sqs_url
+
   lacework_default_account  = "<Lacework Account>"
   lacework_org_map = {
     "<Lacework Sub-Account 1>" = ["<AWS Organization OU 1>", "<AWS Organization OU 2>"],

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,25 @@ variable "lacework_default_account" {
   description = "The catch-all 'default' Lacework Account name to use for CloudTrail data."
 }
 
-variable "lacework_integration_guid" {
+variable "lacework_integration_name" {
   type        = string
-  description = "The GUID for the Org-level Cloudtrail integration to synchronize."
+  default     = ""
+  description = "The name of the Lacework org-level CloudTrail integration."
+}
+
+variable "lacework_iam_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role to use for the Lacework org-level CloudTrail integration."
+}
+
+variable "lacework_iam_role_external_id" {
+  type        = string
+  description = "The External ID of the IAM role to use for the Lacework org-level CloudTrail integration."
+}
+
+variable "lacework_sqs_queue_url" {
+  type        = string
+  description = "The URL of the SQS queue to use for the Lacework org-level CloudTrail integration."
 }
 
 variable "lacework_org_map" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,11 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    aws = "~> 4.0"
+    aws    = "~> 4.0"
+    random = ">= 2.1"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.2"
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR moves the creation of the Lacework CloudTrail integration to within the module.  This allows us to ignore out-of-band changes to the account mapping.

## How did you test this change?

Tested in my AWS Organization.

## Issue

N/A